### PR TITLE
15 new rewards(full list inside)

### DIFF
--- a/content/soundevents/emotes.vsndevts
+++ b/content/soundevents/emotes.vsndevts
@@ -121,6 +121,56 @@
         distance_max = "3500"
     }
 
+    lycan = {
+        type = "dota_update_default"
+        vsnd_files = 
+        [
+            "sounds/vo/lycan/lycan_laugh_03.vsnd"
+        ]
+        volume = "3"
+        distance_max = "3500"
+    }
+
+    templar_assassin = {
+        type = "dota_update_default"
+        vsnd_files = 
+        [
+            "sounds/vo/templar_assassin/temp_refraction_04.vsnd"
+        ]
+        volume = "3"
+        distance_max = "3500"
+    }
+
+    earth_spirit = {
+        type = "dota_update_default"
+        vsnd_files = 
+        [
+            "sounds/vo/earth_spirit/earthspi_kill_07.vsnd"
+        ]
+        volume = "3"
+        distance_max = "3500"
+    }
+
+    tiny = {
+        type = "dota_update_default"
+        vsnd_files = 
+        [
+            "sounds/vo/tiny/tiny_ability_toss_04.vsnd"
+        ]
+        volume = "3"
+        distance_max = "3500"
+    }
+
+    ember_spirit = {
+        type = "dota_update_default"
+        vsnd_files = 
+        [
+            "sounds/vo/ember_spirit/embr_deny_03.vsnd"
+        ]
+        volume = "3"
+        distance_max = "3500"
+    }
+
     Taunt.AM = {
         type = "dota_update_default"
         vsnd_files = 
@@ -193,6 +243,55 @@
         [
             "sounds/weapons/hero/vengeful_spirit/chicken_dance.vsnd"
         ]
+        distance_max = "3500"
+    }
+
+    Taunt.Tinker = {
+        type = "dota_update_default"
+        vsnd_files = 
+        [
+            "sounds/vo/tinker/tink_laugh_13.vsnd"
+        ]
+        volume = "1.5"
+        distance_max = "3500"
+    }
+
+    Taunt.Gyrocopter = {
+        type = "dota_update_default"
+        vsnd_files = 
+        [
+            "sounds/weapons/hero/gyrocopter/taunt_barrel_roll.vsnd"
+        ]
+        distance_max = "3500"
+    }
+
+    Taunt.QOP = {
+        type = "dota_update_default"
+        vsnd_files = 
+        [
+            "sounds/vo/queenofpain/pain_taunt_01.vsnd"
+        ]
+        volume = "1.5"
+        distance_max = "3500"
+    }
+
+    Taunt.WK = {
+        type = "dota_update_default"
+        vsnd_files = 
+        [
+            "sounds/vo/skeleton_king/wraith_lasthit_10.vsnd"
+        ]
+        volume = "3"
+        distance_max = "3500"
+    }
+
+    Taunt.LC = {
+        type = "dota_update_default"
+        vsnd_files = 
+        [
+            "sounds/vo/legion_commander/legcom_dem_duel_05.vsnd"
+        ]
+        volume = "1.5"
         distance_max = "3500"
     }
 

--- a/game/scripts/npc/cosmetics.txt
+++ b/game/scripts/npc/cosmetics.txt
@@ -8,6 +8,13 @@
             "season" "0"
             "set" "hunter_of_kings"
         }
+
+        "2"
+        {
+            "type" "pass"
+            "level" "27"
+            "emote" "default"
+        }
     }
 
     "juggernaut"
@@ -44,6 +51,12 @@
             "type" "elite"
             "season" "6"
             "set" "stormwrought_arbiter"
+        }
+        "2"
+        {
+            "type" "pass"
+            "level" "26"
+            "item" "8189"
         }
     }
 
@@ -124,6 +137,13 @@
                 "sound" "Taunt.Slark"
                 "length" "1.2"
             }
+        }
+
+        "2"
+        {
+            "type" "pass"
+            "level" "38"
+            "item" "7465"
         }
     }
 
@@ -312,6 +332,13 @@
                 "particles/units/heroes/hero_templar_assassin/templar_assassin_meld_hit.vpcf" "particles/econ/items/templar_assassin/templar_assassin_focal/templar_assassin_meld_focal_attack_hit.vpcf"
             }
         }
+
+        "3"
+        {
+            "type" "pass"
+            "level" "30"
+            "emote" "default"
+        }
     }
 
     "storm_spirit"
@@ -322,6 +349,7 @@
             "level" "23"
             "item" "6431"
         }
+
     }
 
     "ember_spirit"
@@ -338,6 +366,13 @@
             "type" "pass"
             "level" "3"
             "item" "7470,7472"
+        }
+
+        "3"
+        {
+            "type" "pass"
+            "level" "39"
+            "emote" "default"
         }
     }
 
@@ -365,6 +400,20 @@
             "particles"
             {
                 "particles/wk_w/wk_w.vpcf" "particles/econ/wk_w/wk_w.vpcf"
+            }
+        }
+
+        "4"
+        {
+            "type" "pass"
+            "level" "40"
+            "taunt"
+            {
+                "type" "static"
+                "activity" "ACT_DOTA_CAST_ABILITY_2"
+                "translate" "frostivus"
+                "sound" "Taunt.WK"
+                "length" "3.0"
             }
         }
     }
@@ -510,6 +559,23 @@
         }
     }
 
+    "tiny"
+    {
+        "1"
+        {
+            "type" "elite"
+            "season" "15"
+            "set" "tiny_igneous_stone"
+        }
+
+        "2"
+        {
+            "type" "pass"
+            "level" "36"
+            "emote" "default"
+        }
+    }
+
     "sand_king"
     {
         "1"
@@ -526,6 +592,105 @@
         {
             "type" "pass_base"
             "emote" "default"
+        }
+
+        "2"
+        {
+            "type" "pass"
+            "level" "34"
+            "taunt"
+            {
+                "type" "static"
+                "activity" "ACT_DOTA_IDLE_RARE"
+                "translate" "loadout"
+                "sound" "Taunt.QOP"
+                "length" "3.5"
+            }
+        }
+    }
+
+    "tinker"
+    {
+        "1"
+        {
+            "type" "pass"
+            "level" "28"
+            "taunt"
+            {
+                "type" "static"
+                "activity" "ACT_DOTA_VICTORY"
+                "translate" "tinker_rollermaw"
+                "sound" "Taunt.Tinker"
+                "length" "4.0"
+            }
+        }
+
+        "2"
+        {
+            "type" "pass"
+            "level" "32"
+            "item" "7143"
+        }
+    }
+
+    "legion_commander"
+    {
+        "1"
+        {
+            "type" "pass"
+            "level" "29"
+            "item" "5810"
+        }
+
+        "2"
+        {
+            "type" "pass"
+            "level" "37"
+            "taunt"
+            {
+                "type" "static"
+                "activity" "ACT_DOTA_TELEPORT"
+                "translate" "dualwield"
+                "sound" "Taunt.LC"
+                "length" "4"
+            }
+        }
+    }
+
+    "gyrocopter"
+    {
+        "1"
+        {
+            "type" "pass"
+            "level" "31"
+            "taunt"
+            {
+                "type" "moving"
+                "activity" "ACT_DOTA_TAUNT"
+                "translate" "taunt_roll_gesture"
+                "sound" "Taunt.Gyrocopter"
+                "length" "2.5"
+            }
+        }
+    }
+
+    "earth_spirit"
+    {
+        "1"
+        {
+            "type" "pass"
+            "level" "33"
+            "emote" "default"
+        }
+    }
+
+    "ursa"
+    {
+        "1"
+        {
+            "type" "pass"
+            "level" "35"
+            "item" "6893"
         }
     }
 }


### PR DESCRIPTION
https://hastebin.com/yixotefena.pl

I had a problems with new WR and Storm 2017 taunts because their 'animation translate modifiers' dont exist in animations.lua file. I've tried to add these modifiers by myself but it still didnt work.
Also I didnt add any "particle" stuff in cosmetics.txt because every item works fine for me. Maybe I'm wrong and these particles should be added but I didnt have any issues with them in dota2test as I said. 

P.S. and I wanted 38 lvl reward to be golden one but its the same model for golden and purple weapons. Some particles stuff is required there probably but I was kinda tired already. Anyway, right now I have no idea how to add/use/load these particles.

P.P.S. В cosmetics.txt поменяй значение в строчке 632 на "6224". Я слишком поздно понял, что иммортал ботинки выглядят лучше, чем голова ><