### PR TITLE
Fixed tiny W was not an arc projectile

### DIFF
--- a/game/scripts/vscripts/abilities/tiny/tiny_w_entity.lua
+++ b/game/scripts/vscripts/abilities/tiny/tiny_w_entity.lua
@@ -1,105 +1,100 @@
-TinyW = TinyW or class({}, nil, UnitEntity)
+TinyW = TinyW or class({}, nil, ArcProjectile)
 
 function TinyW:constructor(round, owner, ability, damage, target, bounces, height)
-    getbase(TinyW).constructor(self, round, DUMMY_UNIT, owner:GetPos())
+    getbase(TinyW).constructor(self,round, {
+        ability = self,
+        owner = owner,
+        from = owner:GetPos(),
+        to = target,
+        graphics = "particles/tiny_w/tiny_w.vpcf",
+        arc = height,
+    })
 
-    self.owner = owner.owner
-    self.hero = owner
-    self.ability = ability
-    self.target = target
-    self.start = owner:GetPos()
-    self.startTime = GameRules:GetGameTime()
     self.bounces = bounces
-    self.height = height
-    self.travelTime = 0.85
     self.effectRadius = 200
-    self.fallingDirection = nil
+    self.Traveltime = 0.85
     self.damage = damage
+    self.speed = (self.to - self.from):Length2D() / self.Traveltime
+    self.arc = height
 
-    self:SetFacing(target - self.start)
-
-    self.particle = ParticleManager:CreateParticle("particles/tiny_w/tiny_w.vpcf", PATTACH_ABSORIGIN_FOLLOW , self.unit)
-
-    self.removeOnDeath = false
-    self:SetInvulnerable(true)
-    self:SetPos(self.start)
-
-    self:CreateAOEMarker()
-end
-
-function TinyW:CreateAOEMarker()
-    CreateEntityAOEMarker(self.target, self.effectRadius, self.travelTime + 0.1, { 255, 255, 255 }, 0.65, true)
-end
-
-function TinyW:CanFall()
-    return false
+    CreateEntityAOEMarker(self.to, self.effectRadius, (self.to - self.from):Length2D() / self.speed, { 255, 255, 255 }, 0.65, true)
 end
 
 function TinyW:Update()
-    getbase(TinyW).Update(self)
+    getbase(ArcProjectile).Update(self)
+
+    local pos = self:GetPos()
 
     if self.falling then
         self:SetPos(self:GetPos() + self.fallingDirection)
+        self:SetFacing(self:GetPos() - pos)
         return
     end
 
-    local time = GameRules:GetGameTime() - self.startTime
-    local progress = time / self.travelTime
-    local delta = self.target - self.start
-    local dir = delta:Normalized() * (progress * delta:Length())
-    local height = ParabolaZ(self.height, delta:Length(), dir:Length())
-    local result = self.start + dir
-    local prevPos = self:GetPos()
+    if IsOutOfTheMap(pos) then
+        self:Destroy()
+        return
+    end
 
-    self:SetPos(result + Vector(0, 0, height))
+    self:SetPos(self:GetNextPosition(pos))
 
-    if progress >= 1.0 then
-        local effectPosition = self:GetPos()
+    local initialD = (self.to - pos):Length2D()
+    local resultD = (self.to - self:GetPos()):Length2D()
 
-        if not Spells.TestPoint(effectPosition, self:GetUnit()) then
+    if (self.to - self:GetPos()):Length() <= self:GetSpeed() / 30 or resultD >= initialD then
+        if not Spells.TestPoint(self:GetPos()) then
             self.falling = true
-            self.fallingDirection = self:GetPos() - prevPos
+            self.fallingDirection = self:GetPos() - pos
             return
         end
 
-        effectPosition.z = GetGroundHeight(effectPosition, self.unit)
-        ImmediateEffectPoint("particles/tiny_w/tiny_w_explode.vpcf", PATTACH_ABSORIGIN, self, effectPosition)
-
-        GridNav:DestroyTreesAroundPoint(result, self.effectRadius, false)
-
-        self.hero:AreaEffect({
-            ability = self.ability,
-            filter = Filters.Area(effectPosition, self.effectRadius),
-            damage = self.damage,
-            modifier = { name = "modifier_stunned_lua", duration = 0.7, ability = self.ability },
-        })
-
-        ScreenShake(effectPosition, 5, 150, 0.25, 2000, 0, true)
-        Spells:GroundDamage(effectPosition, self.effectRadius, self.hero, false, 0.5)
-
-        self:EmitSound("Arena.Tiny.HitW")
-
-        if self.bounces > 0 then
-            self.damage = math.max(self.damage - 1, 1)
-            self.start = self.position
-            self.target = self.target + delta:Normalized() * delta:Length() / 2
-            self.height = self.height / 2
-            self.bounces = self.bounces - 1
-            self.startTime = GameRules:GetGameTime()
-            self.travelTime = self.travelTime * 0.75
-
-            self.target.z = GetGroundHeight(self.target, self.unit)
-
-            self:CreateAOEMarker()
-        else
-            self:Destroy()
-        end
+        self:hitFunction()
     end
 end
 
-function TinyW:Remove()
-    ParticleManager:DestroyParticle(self.particle, false)
-    ParticleManager:ReleaseParticleIndex(self.particle)
+function TinyW:hitFunction()
+    local effectPosition = self:GetPos()
 
-    getbase(TinyW).Remove(self)
+    self:EmitSound("Arena.Tiny.HitW")
+
+    ScreenShake(effectPosition, 5, 150, 0.25, 2000, 0, true)
+    Spells:GroundDamage(effectPosition, self.effectRadius, self.hero, false, 0.5)
+
+    effectPosition.z = GetGroundHeight(effectPosition, self.unit)
+    ImmediateEffectPoint("particles/tiny_w/tiny_w_explode.vpcf", PATTACH_ABSORIGIN, self, effectPosition)
+
+    GridNav:DestroyTreesAroundPoint(self:GetPos() + (self.to - self.from):Normalized() * self.speed / 30, self.effectRadius, false)
+
+    self.hero:AreaEffect({
+        ability = self.ability,
+        filter = Filters.Area(effectPosition, self.effectRadius),
+        damage = self.damage,
+        modifier = { name = "modifier_stunned_lua", duration = 0.7, ability = self.ability },
+    })
+
+    if self.bounces > 0 then
+        local delta = self.to - self.from
+
+        self.damage = math.max(self.damage - 1, 1)
+        self.from = self.position
+        self.to = self.to + delta:Normalized() * delta:Length() / 2
+        self.arc = self.arc / 2
+        self.bounces = self.bounces - 1
+        self.speed = self.speed * (self.Traveltime * 0.75)
+        self.to.z = GetGroundHeight(self.to, self.unit)
+
+        CreateEntityAOEMarker(self.to, self.effectRadius, (self.from - self.to):Length2D() / self.speed + 0.1, { 255, 255, 255 }, 0.65, true)
+    else
+        self:Destroy()
+    end
+end
+
+function TinyW:GetNextPosition(pos)
+    local result = pos + ((self.to - self.from):Normalized() * (self:GetSpeed() / 30))
+    local d = (self.from - self.to):Length2D()
+    local x = (self.from - result):Length2D()
+
+    result.z = ParabolaZ(self.arc, d, x)
+
+    return result
 end


### PR DESCRIPTION
issue - https://github.com/DoctorGester/crumbling-island-arena/issues/349

Существует баг когда при попадании в R союзного тинкера выдаётся ошибка: "scripts\vscripts\abilities\tinker\entity_tinker_r.lua:71: attempt to index field 'owner' (a nil value)". Без понятия почему это происходит, но вроде никаких ошибок связанных с этим не заметил. К тому же такая-же ошибка есть и для Q тини и вроде как на него никто не жаловался.